### PR TITLE
Obtain available service-job contents

### DIFF
--- a/MSMetaEnhancer/app.py
+++ b/MSMetaEnhancer/app.py
@@ -60,15 +60,6 @@ class Application:
         """
         self.spectra = Curator().curate_spectra(self.spectra)
 
-    def get_service_conversions(self, service):
-        """
-        Method to get all conversions for given service.
-
-        :param service: given Converter subclass
-        :return: a list of available conversion functions
-        """
-        return service.get_conversions()
-
     async def annotate_spectra(self, services, jobs=None, repeat=False):
         """
         Annotates current Spectra data by specified jobs.
@@ -88,7 +79,7 @@ class Application:
             if not jobs:
                 jobs = []
                 for service in services.values():
-                    jobs += self.get_service_conversions(service)
+                    jobs += service.get_conversion_functions()
             jobs = convert_to_jobs(jobs)
 
             logger.set_target_attributes(jobs, len(self.spectra.spectrums))

--- a/MSMetaEnhancer/app.py
+++ b/MSMetaEnhancer/app.py
@@ -64,6 +64,7 @@ class Application:
         """
         Method to get all conversions for given service.
 
+        :param service: given Converter subclass
         :return: a list of available conversion functions
         """
         return service.get_conversions()

--- a/MSMetaEnhancer/app.py
+++ b/MSMetaEnhancer/app.py
@@ -60,6 +60,14 @@ class Application:
         """
         self.spectra = Curator().curate_spectra(self.spectra)
 
+    def get_service_conversions(self, service):
+        """
+        Method to get all conversions for given service.
+
+        :return: a list of available conversion functions
+        """
+        return service.get_conversions()
+
     async def annotate_spectra(self, services, jobs=None, repeat=False):
         """
         Annotates current Spectra data by specified jobs.
@@ -77,7 +85,9 @@ class Application:
 
             # create all possible jobs if not given
             if not jobs:
-                jobs = annotator.get_all_conversions()
+                jobs = []
+                for service in services.values():
+                    jobs += self.get_service_conversions(service)
             jobs = convert_to_jobs(jobs)
 
             logger.set_target_attributes(jobs, len(self.spectra.spectrums))

--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -77,18 +77,3 @@ class Annotator:
             else:
                 raise TargetAttributeNotRetrieved('No data obtained from the specified job.')
         return metadata, cache
-
-    def get_all_conversions(self):
-        """
-        Method to compute all available conversion functions of all available Services.
-
-        Assumes that the functions always have from {source}_to_{target}
-
-        :return: a list of available conversion functions
-        """
-        jobs = []
-        for service in self.services:
-            methods = [method_name for method_name in dir(self.services[service]) if '_to_' in method_name]
-            for method in methods:
-                jobs.append((*method.split('_to_'), service))
-        return jobs

--- a/MSMetaEnhancer/libs/services/Converter.py
+++ b/MSMetaEnhancer/libs/services/Converter.py
@@ -106,7 +106,7 @@ class Converter:
         for conversion in conversions:
             create_top_level_method(self, *conversion)
 
-    def get_conversions(self):
+    def get_conversion_functions(self):
         """
         Method to compute all available conversion functions.
 

--- a/MSMetaEnhancer/libs/services/Converter.py
+++ b/MSMetaEnhancer/libs/services/Converter.py
@@ -106,6 +106,20 @@ class Converter:
         for conversion in conversions:
             create_top_level_method(self, *conversion)
 
+    def get_conversions(self):
+        """
+        Method to compute all available conversion functions.
+
+        Assumes that the functions always have from {source}_to_{target}
+
+        :return: a list of available conversion functions
+        """
+        jobs = []
+        methods = [method_name for method_name in dir(self) if '_to_' in method_name]
+        for method in methods:
+            jobs.append((*method.split('_to_'), self.service_name))
+        return jobs
+
 
 def create_top_level_method(obj, source, target, method):
     """

--- a/MSMetaEnhancer/libs/services/__init__.py
+++ b/MSMetaEnhancer/libs/services/__init__.py
@@ -2,3 +2,5 @@ from MSMetaEnhancer.libs.services.CIR import CIR
 from MSMetaEnhancer.libs.services.CTS import CTS
 from MSMetaEnhancer.libs.services.NLM import NLM
 from MSMetaEnhancer.libs.services.PubChem import PubChem
+
+__all__ = ['CIR', 'CTS', 'NLM', 'PubChem']

--- a/tests/test_CIR.py
+++ b/tests/test_CIR.py
@@ -39,5 +39,5 @@ def test_incorrect_behavior(arg, value, method):
 
 
 def test_get_conversions():
-    jobs = CIR(None).get_conversions()
+    jobs = CIR(None).get_conversion_functions()
     assert ("smiles", "inchikey", "CIR") in jobs

--- a/tests/test_CIR.py
+++ b/tests/test_CIR.py
@@ -36,3 +36,8 @@ def test_correct_behavior(arg, value, expected, method):
 def test_incorrect_behavior(arg, value, method):
     with pytest.raises(UnknownResponse):
         asyncio.run(wrap_with_session(CIR, method, [value]))
+
+
+def test_get_conversions():
+    jobs = CIR(None).get_conversions()
+    assert ("smiles", "inchikey", "CIR") in jobs

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -60,5 +60,5 @@ def test_format(value, size):
 
 
 def test_get_conversions():
-    jobs = CTS(None).get_conversions()
+    jobs = CTS(None).get_conversion_functions()
     assert ("inchikey", "name", "CTS") in jobs

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -57,3 +57,8 @@ def test_format(value, size):
     assert len(response_json) == 1
     assert 'results' in response_json[0]
     assert len(response_json[0]['results']) == size
+
+
+def test_get_conversions():
+    jobs = CTS(None).get_conversions()
+    assert ("inchikey", "name", "CTS") in jobs

--- a/tests/test_NLM.py
+++ b/tests/test_NLM.py
@@ -56,3 +56,8 @@ def test_format():
 
     table = pd.read_csv(StringIO(response), sep='\t')
     assert not table.empty
+
+
+def test_get_conversions():
+    jobs = NLM(None).get_conversions()
+    assert ("name", "inchikey", "NLM") in jobs

--- a/tests/test_NLM.py
+++ b/tests/test_NLM.py
@@ -59,5 +59,5 @@ def test_format():
 
 
 def test_get_conversions():
-    jobs = NLM(None).get_conversions()
+    jobs = NLM(None).get_conversion_functions()
     assert ("name", "inchikey", "NLM") in jobs

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -62,17 +62,3 @@ def test_execute_job_with_cache():
 
     with pytest.raises(TargetAttributeNotRetrieved):
         metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, dict()))
-
-
-def test_get_all_conversions():
-    pubchem = mock.Mock()
-    pubchem.A_to_B = mock.Mock()
-    pubchem.B_to_C = mock.Mock()
-
-    cts = mock.Mock()
-    cts.X_to_Y = mock.Mock()
-
-    services = {'PubChem': pubchem, 'CTS': cts}
-    annotator = Annotator(services)
-
-    assert set(annotator.get_all_conversions()) == {('A', 'B', 'PubChem'), ('B', 'C', 'PubChem'), ('X', 'Y', 'CTS')}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -131,6 +131,7 @@ def test_services_available():
 def test_lru_cache(service, args):
     async def run():
         async with aiohttp.ClientSession() as session:
+            from MSMetaEnhancer.libs.services import CTS, CIR
             converter = eval(service)(session)
             converter.query_the_service.cache_clear()
 

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -70,7 +70,7 @@ def test_format():
 def test_get_conversions():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    jobs = PubChem(None).get_conversions()
+    jobs = PubChem(None).get_conversion_functions()
     loop.close()
 
     assert ("inchi", "iupac_name", "PubChem") in jobs

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -65,3 +65,12 @@ def test_format():
     assert 'results' in response_json
     assert 'bindings' in response_json['results']
     assert len(response_json['results']['bindings']) > 1
+
+
+def test_get_conversions():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    jobs = PubChem(None).get_conversions()
+    loop.close()
+
+    assert ("inchi", "iupac_name", "PubChem") in jobs


### PR DESCRIPTION
Changed how individual conversions can be obtained for a particular service. This can be used by a wrapper to get list of available services and their respective conversion methods. Close #19.

The tests are failing because CTS is misbehaving #54 (again).