### PR TITLE
Generate conversion job options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Added
+- `generate_options()` function in `Galaxy` submodule to create all possible conversions supported by the tool in a format suitable for the galaxy tool form [#58](https://github.com/RECETOX/MSMetaEnhancer/pull/58)
 ### Changed
 ### Removed
 

--- a/MSMetaEnhancer/libs/services/__init__.py
+++ b/MSMetaEnhancer/libs/services/__init__.py
@@ -3,4 +3,4 @@ from MSMetaEnhancer.libs.services.CTS import CTS
 from MSMetaEnhancer.libs.services.NLM import NLM
 from MSMetaEnhancer.libs.services.PubChem import PubChem
 
-__all__ = ['CIR', 'CTS', 'NLM', 'PubChem']
+__all__ = ['PubChem', 'CTS', 'CIR', 'NLM']

--- a/galaxy/generate_options.py
+++ b/galaxy/generate_options.py
@@ -1,8 +1,7 @@
-import asyncio
 import sys
 import os
 
-# this add to path eBCSgen home dir, so it can be called from anywhere
+# this add to path the home dir, so it can be called from anywhere
 sys.path.append(os.path.split(sys.path[0])[0])
 
 from MSMetaEnhancer.libs.services import *
@@ -11,11 +10,8 @@ from MSMetaEnhancer.libs.services import __all__ as services
 
 def generate_options():
     jobs = []
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     for service in services:
         jobs += (eval(service)(None).get_conversion_functions())
-    loop.close()
 
     for job in jobs:
         print(f'<option value="{job[0],job[1],job[2]}">{job[2]}: {job[0]} -> {job[1]}</option>')

--- a/galaxy/generate_options.py
+++ b/galaxy/generate_options.py
@@ -14,7 +14,7 @@ def generate_options():
         jobs += (eval(service)(None).get_conversion_functions())
 
     for job in jobs:
-        print(f'<option value="{job[0],job[1],job[2]}">{job[2]}: {job[0]} -> {job[1]}</option>')
+        print(f'<option value="{job[0]} {job[1]} {job[2]}">{job[2]}: {job[0]} -> {job[1]}</option>')
 
 
 if __name__ == '__main__':

--- a/galaxy/generate_options.py
+++ b/galaxy/generate_options.py
@@ -1,0 +1,25 @@
+import asyncio
+import sys
+import os
+
+# this add to path eBCSgen home dir, so it can be called from anywhere
+sys.path.append(os.path.split(sys.path[0])[0])
+
+from MSMetaEnhancer.libs.services import *
+from MSMetaEnhancer.libs.services import __all__ as services
+
+
+def generate_options():
+    jobs = []
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    for service in services:
+        jobs += (eval(service)(None).get_conversion_functions())
+    loop.close()
+
+    for job in jobs:
+        print(f'<option value="{job[0],job[1],job[2]}">{job[2]}: {job[0]} -> {job[1]}</option>')
+
+
+if __name__ == '__main__':
+    generate_options()


### PR DESCRIPTION
Added script to generate conversion job options for Galaxy macro. These are print to command line and can be copied in place of macro `job_options` in respective Galaxy tool wrapper.