### PR TITLE
59 Validate metadata

### DIFF
--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -1,3 +1,4 @@
+from MSMetaEnhancer.libs.Curator import Curator
 from MSMetaEnhancer.libs.utils import logger
 from MSMetaEnhancer.libs.utils.Errors import ConversionNotSupported, TargetAttributeNotRetrieved, \
     SourceAttributeNotAvailable, ServiceNotAvailable, UnknownResponse
@@ -10,6 +11,7 @@ class Annotator:
     """
     def __init__(self, services):
         self.services = services
+        self.curator = Curator()
 
     async def annotate(self, spectra, jobs, repeat=False):
         """
@@ -75,6 +77,7 @@ class Annotator:
         else:
             if service.is_available:
                 result = await service.convert(job.source, job.target, data)
+                result = self.curator.filter_invalid_metadata(result)
                 cache[job.service].update(result)
                 if job.target in cache[job.service]:
                     metadata[job.target] = cache[job.service][job.target]

--- a/MSMetaEnhancer/libs/Curator.py
+++ b/MSMetaEnhancer/libs/Curator.py
@@ -1,3 +1,6 @@
+from matchms import utils
+
+
 class Curator:
     """
     Curator makes sure that all data is curated before the actual annotation can proceed.
@@ -36,3 +39,26 @@ class Curator:
         if "-" not in cas_number:
             return f'{cas_number[:-3]}-{cas_number[-3:-1]}-{cas_number[-1]}'
         return cas_number
+
+    @staticmethod
+    def filter_invalid_metadata(metadata):
+        """
+        Validates metadata and filters out invalid ones.
+
+        :param metadata: metadata content
+        :return: only valid metadata
+        """
+        filters = {
+            'smiles': utils.is_valid_smiles,
+            'inchi': utils.is_valid_inchi,
+            'inchikey': utils.is_valid_inchikey
+        }
+
+        valid_metadata = {}
+        for (attribute, value) in metadata.items():
+            if attribute in filters.keys():
+                if filters[attribute](value):
+                    valid_metadata[attribute] = value
+            else:
+                valid_metadata[attribute] = value
+        return valid_metadata

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -18,3 +18,4 @@ dependencies:
   - pytest-aiohttp
   - pytest-cov
   - pytest-dependency
+  - rdkit

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - asyncstdlib
     - frozendict
     - tabulate
+    - rdkit
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matchms~=0.9.2
+matchms~=0.11.0
 pandas~=1.2.4
 requests~=2.25.1
 mock~=4.0.3
@@ -12,3 +12,4 @@ tabulate~=0.8.9
 sphinx==4.2.0
 sphinx_rtd_theme==1.0.0
 myst-parser==0.15.2
+rdkit-pypi~=2021.9.3

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from MSMetaEnhancer.libs.Curator import Curator
 
 
@@ -5,3 +7,14 @@ def test_fix_cas_number():
     curator = Curator()
     assert curator.fix_cas_number('7783893') == '7783-89-3'
     assert curator.fix_cas_number('7783-89-3') == '7783-89-3'
+
+
+@pytest.mark.parametrize('metadata, validated_metadata', [
+    [{'formula': 'CH4', 'smiles': 'C', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'},
+     {'formula': 'CH4', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'}],
+    [{'inchikey': '<html>random content</html>'}, {}],
+    [{'smiles': 'CC(NC(C)=O)C#N'}, {'smiles': 'CC(NC(C)=O)C#N'}]
+])
+def test_filter_invalid_metadata(metadata, validated_metadata):
+    curator = Curator()
+    assert curator.filter_invalid_metadata(metadata) == validated_metadata


### PR DESCRIPTION
There were cases when obtained metadata from a service had incorrect content (e.g. #59). This concerns mostly smiles, inchi, and inchikey, since those have defined form. We have covered this issue by using matchms validators, ensuring that each such attribute is valid.

Close #59.