### PR TITLE
Additional conversions and validation logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * passed `multidict` instead of `frozendict` to `aiohttp.ClientSession.post` (required by package)
 * take only first result when there are multiple hits in CIR conversions [#69](https://github.com/RECETOX/MSMetaEnhancer/issues/69)
+* support `ISOMERIC_SMILES` and `CANONICAL_SMILES` in PubChem instead of generic `SMILES` [#67](https://github.com/RECETOX/MSMetaEnhancer/issues/67)
 ### Removed
 
 ## [0.1.2] - 2022-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dev] - unreleased
 ### Added
 * multidict package requirement
+* tracking of attributes validation in log [#68](https://github.com/RECETOX/MSMetaEnhancer/issues/68)
 ### Changed
 * passed `multidict` instead of `frozendict` to `aiohttp.ClientSession.post` (required by package)
 * take only first result when there are multiple hits in CIR conversions [#69](https://github.com/RECETOX/MSMetaEnhancer/issues/69)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * multidict package requirement
 * tracking of attributes validation in log [#68](https://github.com/RECETOX/MSMetaEnhancer/issues/68)
+* CIR: Inchi -> SMILES conversion [#66](https://github.com/RECETOX/MSMetaEnhancer/issues/66)
 ### Changed
 * passed `multidict` instead of `frozendict` to `aiohttp.ClientSession.post` (required by package)
 * take only first result when there are multiple hits in CIR conversions [#69](https://github.com/RECETOX/MSMetaEnhancer/issues/69)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Added
+* multidict package requirement
 ### Changed
+* passed `multidict` instead of `frozendict` to `aiohttp.ClientSession.post` (required by package)
+* take only first result when there are multiple hits in CIR conversions [#69](https://github.com/RECETOX/MSMetaEnhancer/issues/69)
 ### Removed
 
 ## [0.1.2] - 2022-01-06

--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -37,7 +37,7 @@ class Annotator:
             for job in jobs:
                 if job.target not in metadata:
                     try:
-                        metadata, cache = await self.execute_job_with_cache(job, metadata, cache)
+                        metadata, cache = await self.execute_job_with_cache(job, metadata, cache, warning)
                         if repeat:
                             added_metadata = True
                     except (ConversionNotSupported, TargetAttributeNotRetrieved, UnknownResponse) as exc:
@@ -56,7 +56,7 @@ class Annotator:
         spectra.metadata = metadata
         return spectra
 
-    async def execute_job_with_cache(self, job, metadata, cache):
+    async def execute_job_with_cache(self, job, metadata, cache, warning):
         """
         Execute given job in cached mode. Cache is service specific
         and spectra specific.
@@ -66,6 +66,7 @@ class Annotator:
         :param job: given job to be executed
         :param metadata: data to be annotated by the job
         :param cache: given cache for this spectra
+        :param warning: object storing warnings related to current metadata
         :return: updated metadata and cache
         """
         # make sure the job makes sense
@@ -77,7 +78,7 @@ class Annotator:
         else:
             if service.is_available:
                 result = await service.convert(job.source, job.target, data)
-                result = self.curator.filter_invalid_metadata(result)
+                result = self.curator.filter_invalid_metadata(result, warning, job)
                 cache[job.service].update(result)
                 if job.target in cache[job.service]:
                     metadata[job.target] = cache[job.service][job.target]

--- a/MSMetaEnhancer/libs/Curator.py
+++ b/MSMetaEnhancer/libs/Curator.py
@@ -54,6 +54,8 @@ class Curator:
         """
         filters = {
             'smiles': utils.is_valid_smiles,
+            'canonical_smiles': utils.is_valid_smiles,
+            'isomeric_smiles': utils.is_valid_smiles,
             'inchi': utils.is_valid_inchi,
             'inchikey': utils.is_valid_inchikey
         }

--- a/MSMetaEnhancer/libs/Curator.py
+++ b/MSMetaEnhancer/libs/Curator.py
@@ -1,4 +1,6 @@
 from matchms import utils
+from MSMetaEnhancer.libs.utils import logger
+from MSMetaEnhancer.libs.utils.Errors import InvalidAttributeFormat
 
 
 class Curator:
@@ -41,11 +43,13 @@ class Curator:
         return cas_number
 
     @staticmethod
-    def filter_invalid_metadata(metadata):
+    def filter_invalid_metadata(metadata, warning, job):
         """
         Validates metadata and filters out invalid ones.
 
         :param metadata: metadata content
+        :param warning: object storing warnings related to current metadata
+        :param job: executed job
         :return: only valid metadata
         """
         filters = {
@@ -59,6 +63,9 @@ class Curator:
             if attribute in filters.keys():
                 if filters[attribute](value):
                     valid_metadata[attribute] = value
+                else:
+                    warning.add_warning(
+                        InvalidAttributeFormat(f'Job {job} obtained {attribute} in invalid format: {value}'))
             else:
                 valid_metadata[attribute] = value
         return valid_metadata

--- a/MSMetaEnhancer/libs/services/CIR.py
+++ b/MSMetaEnhancer/libs/services/CIR.py
@@ -86,3 +86,15 @@ class CIR(Converter):
         response = await self.query_the_service('CIR', args)
         if response:
             return {'inchikey': response.split('\n')[0][9:]}
+
+    async def inchi_to_smiles(self, inchi):
+        """
+        Convert InChi to SMILES using CIR web service
+
+        :param inchi: given InChi
+        :return: obtained SMILES
+        """
+        args = f'{inchi}/smiles'
+        response = await self.query_the_service('CIR', args)
+        if response:
+            return {'smiles': response.split('\n')[0]}

--- a/MSMetaEnhancer/libs/services/CIR.py
+++ b/MSMetaEnhancer/libs/services/CIR.py
@@ -25,7 +25,7 @@ class CIR(Converter):
         args = f'{cas_number}/smiles?resolver=cas_number'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'smiles': response.split('\n')[0]}
+            return {'smiles': self.retrieve_first(response)}
 
     async def inchikey_to_smiles(self, inchikey):
         """
@@ -37,7 +37,7 @@ class CIR(Converter):
         args = f'{inchikey}/smiles'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'smiles': response.split('\n')[0]}
+            return {'smiles': self.retrieve_first(response)}
 
     async def inchikey_to_inchi(self, inchikey):
         """
@@ -49,7 +49,7 @@ class CIR(Converter):
         args = f'{inchikey}/stdinchi'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'inchi': response.split('\n')[0]}
+            return {'inchi':self.retrieve_first(response)}
 
     async def inchikey_to_casno(self, inchikey):
         """
@@ -61,7 +61,7 @@ class CIR(Converter):
         args = f'{inchikey}/cas'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'casno': response.split('\n')[0]}
+            return {'casno': self.retrieve_first(response)}
 
     async def inchikey_to_formula(self, inchikey):
         """
@@ -73,7 +73,7 @@ class CIR(Converter):
         args = f'{inchikey}/formula'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'formula': response.split('\n')[0]}
+            return {'formula': self.retrieve_first(response)}
 
     async def smiles_to_inchikey(self, smiles):
         """
@@ -85,7 +85,7 @@ class CIR(Converter):
         args = f'{smiles}/stdinchikey'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'inchikey': response.split('\n')[0][9:]}
+            return {'inchikey': self.retrieve_first(response)[9:]}
 
     async def inchi_to_smiles(self, inchi):
         """
@@ -97,4 +97,15 @@ class CIR(Converter):
         args = f'{inchi}/smiles'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'smiles': response.split('\n')[0]}
+            return {'smiles': self.retrieve_first(response)}
+
+    @staticmethod
+    def retrieve_first(response):
+        """
+        CIR often returns multiple hits separated by a newline.
+        This method takes the first hit only.
+
+        :param response: given response from CIR
+        :return: only first hit
+        """
+        return response.split('\n')[0]

--- a/MSMetaEnhancer/libs/services/CIR.py
+++ b/MSMetaEnhancer/libs/services/CIR.py
@@ -25,7 +25,7 @@ class CIR(Converter):
         args = f'{cas_number}/smiles?resolver=cas_number'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'smiles': response}
+            return {'smiles': response.split('\n')[0]}
 
     async def inchikey_to_smiles(self, inchikey):
         """
@@ -49,7 +49,7 @@ class CIR(Converter):
         args = f'{inchikey}/stdinchi'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'inchi': response}
+            return {'inchi': response.split('\n')[0]}
 
     async def inchikey_to_casno(self, inchikey):
         """
@@ -61,7 +61,7 @@ class CIR(Converter):
         args = f'{inchikey}/cas'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'casno': response}
+            return {'casno': response.split('\n')[0]}
 
     async def inchikey_to_formula(self, inchikey):
         """
@@ -73,7 +73,7 @@ class CIR(Converter):
         args = f'{inchikey}/formula'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'formula': response}
+            return {'formula': response.split('\n')[0]}
 
     async def smiles_to_inchikey(self, smiles):
         """
@@ -85,4 +85,4 @@ class CIR(Converter):
         args = f'{smiles}/stdinchikey'
         response = await self.query_the_service('CIR', args)
         if response:
-            return {'inchikey': response[9:]}
+            return {'inchikey': response.split('\n')[0][9:]}

--- a/MSMetaEnhancer/libs/services/Converter.py
+++ b/MSMetaEnhancer/libs/services/Converter.py
@@ -1,5 +1,6 @@
 import aiohttp
 from asyncstdlib import lru_cache
+from multidict import MultiDict
 
 
 from aiohttp.client_exceptions import ServerDisconnectedError
@@ -61,6 +62,7 @@ class Converter:
                 async with self.session.get(url, headers=headers) as response:
                     return await self.process_request(response, url, method)
             else:
+                data = MultiDict(data)
                 async with self.session.post(url, data=data, headers=headers) as response:
                     return await self.process_request(response, url, method)
         except (ServerDisconnectedError, aiohttp.client_exceptions.ClientConnectorError, TimeoutError):

--- a/MSMetaEnhancer/libs/services/PubChem.py
+++ b/MSMetaEnhancer/libs/services/PubChem.py
@@ -22,16 +22,19 @@ class PubChem(Converter):
                            {'code': 'iupac_name', 'label': 'CHEMINF_000382'},
                            {'code': 'inchikey', 'label': 'CHEMINF_000399'},
                            {'code': 'formula', 'label': 'CHEMINF_000335'},
-                           {'code': 'smiles', 'label': 'CHEMINF_000376'}]
+                           {'code': 'canonical_smiles', 'label': 'CHEMINF_000376'},
+                           {'code': 'isomeric_smiles', 'label': 'CHEMINF_000379'}]
 
         # generate top level methods defining allowed conversions
         conversions = [('name', 'inchi', 'from_name'),
                        ('name', 'iupac_name', 'from_name'),
                        ('name', 'formula', 'from_name'),
-                       ('name', 'smiles', 'from_name'),
+                       ('name', 'canonical_smiles', 'from_name'),
+                       ('name', 'isomeric_smiles', 'from_name'),
                        ('inchi', 'iupac_name', 'from_inchi'),
                        ('inchi', 'formula', 'from_inchi'),
-                       ('inchi', 'smiles', 'from_inchi')]
+                       ('inchi', 'canonical_smiles', 'from_inchi'),
+                       ('inchi', 'isomeric_smiles', 'from_inchi')]
         self.create_top_level_conversion_methods(conversions)
 
         # used to limit the maximal number of simultaneous requests being processed

--- a/MSMetaEnhancer/libs/utils/Errors.py
+++ b/MSMetaEnhancer/libs/utils/Errors.py
@@ -24,3 +24,7 @@ class ServiceNotAvailable(Exception):
 
 class UnknownResponse(Exception):
     pass
+
+
+class InvalidAttributeFormat(Exception):
+    pass

--- a/MSMetaEnhancer/libs/utils/Logger.py
+++ b/MSMetaEnhancer/libs/utils/Logger.py
@@ -61,7 +61,6 @@ class Logger:
     def add_warning(self, warning):
         """
         Logs given exception as a Warning.
-        Increases number of failed jobs.
 
         :param warning: LogWarning
         """
@@ -141,7 +140,6 @@ class LogWarning:
     def add_warning(self, exc: Exception):
         """
         Logs given exception as a Warning.
-        Increases number of failed jobs.
 
         :param exc: given exception
         """

--- a/MSMetaEnhancer/libs/utils/Monitor.py
+++ b/MSMetaEnhancer/libs/utils/Monitor.py
@@ -36,7 +36,7 @@ class Monitor(Thread):
         try:
             result = requests.get(url, timeout=5)
             return result.status_code == 200
-        except (requests.exceptions.ConnectionError, TimeoutError):
+        except (requests.exceptions.ConnectionError, TimeoutError, requests.exceptions.ReadTimeout):
             return False
 
     def run(self):

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -19,3 +19,4 @@ dependencies:
   - pytest-cov
   - pytest-dependency
   - rdkit
+  - multidict

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - frozendict
     - tabulate
     - rdkit
+    - multidict
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sphinx==4.2.0
 sphinx_rtd_theme==1.0.0
 myst-parser==0.15.2
 rdkit-pypi~=2021.9.3
+multidict~=5.2.0

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -29,8 +29,9 @@ def test_annotate(data, expected, repeat, mocked):
 
 
 def test_execute_job_with_cache():
+    warning = mock.Mock()
     curator = mock.Mock()
-    curator.filter_invalid_metadata = mock.MagicMock(side_effect=lambda a: a)
+    curator.filter_invalid_metadata = mock.MagicMock(side_effect=lambda a, b, c: a)
 
     pubchem = mock.Mock()
     pubchem.convert = mock.AsyncMock(return_value={'smiles': '$SMILES'})
@@ -40,7 +41,7 @@ def test_execute_job_with_cache():
 
     annotator = Annotator({'PubChem': pubchem})
     annotator.curator = curator
-    metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'inchi': '$InChi'}, dict()))
+    metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'inchi': '$InChi'}, dict(), warning))
     assert metadata == {'inchi': '$InChi', 'smiles': '$SMILES'}
 
     # already cached
@@ -55,7 +56,7 @@ def test_execute_job_with_cache():
 
     annotator = Annotator({'CTS': cts})
     annotator.curator = curator
-    metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, cache))
+    metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, cache, warning))
     assert metadata == {'smiles': '$SMILES', 'formula': '$FORMULA'}
 
     # no data retrieved
@@ -67,4 +68,4 @@ def test_execute_job_with_cache():
     annotator.curator = curator
 
     with pytest.raises(TargetAttributeNotRetrieved):
-        metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, dict()))
+        metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, dict(), warning))

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -1,6 +1,8 @@
 import pytest
 
 from MSMetaEnhancer.libs.Curator import Curator
+from MSMetaEnhancer.libs.utils.Job import Job
+from MSMetaEnhancer.libs.utils.Logger import LogWarning
 
 
 def test_fix_cas_number():
@@ -9,12 +11,15 @@ def test_fix_cas_number():
     assert curator.fix_cas_number('7783-89-3') == '7783-89-3'
 
 
-@pytest.mark.parametrize('metadata, validated_metadata', [
+@pytest.mark.parametrize('metadata, validated_metadata, warnings_size', [
     [{'formula': 'CH4', 'smiles': 'C', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'},
-     {'formula': 'CH4', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'}],
-    [{'inchikey': '<html>random content</html>'}, {}],
-    [{'smiles': 'CC(NC(C)=O)C#N'}, {'smiles': 'CC(NC(C)=O)C#N'}]
+     {'formula': 'CH4', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'}, 1],
+    [{'inchikey': '<html>random content</html>'}, {}, 1],
+    [{'smiles': 'CC(NC(C)=O)C#N'}, {'smiles': 'CC(NC(C)=O)C#N'}, 0]
 ])
-def test_filter_invalid_metadata(metadata, validated_metadata):
+def test_filter_invalid_metadata(metadata, validated_metadata, warnings_size):
+    warning = LogWarning(dict())
+    job = Job(('smiles', 'inchi', 'service'))
     curator = Curator()
-    assert curator.filter_invalid_metadata(metadata) == validated_metadata
+    assert curator.filter_invalid_metadata(metadata, warning, job) == validated_metadata
+    assert len(warning.warnings) == warnings_size


### PR DESCRIPTION
This PR targets several smaller issues:

* fixed bug when passing `frozendict` to `aiohttp.ClientSession.post` ([not supported anymore](https://github.com/aio-libs/aiohttp/blob/1dbfbb433f3f7cd05ca97288805dec9e296d75de/aiohttp/formdata.py#L94) - this issue might have been undetected for longer time) by passing `multidict` instead (plus added `multidict` package to requirements)
* fixed handling of results when there are multiple hits in CIR conversions (close #69)
* added tracking of attributes validation to log (close #68)
* added CIR: Inchi -> SMILES conversion (close #66)
* differentiate between canonical and isomeric smiles in PubChem (close #67)

