### PR TITLE
Reintroduce PubChem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Added
+* reintroduced PubChem service using direct REST web interface
 ### Changed
 * renamed PubChem service to IDSM to avoid confusion
 ### Removed

--- a/MSMetaEnhancer/libs/services/CTS.py
+++ b/MSMetaEnhancer/libs/services/CTS.py
@@ -20,7 +20,7 @@ class CTS(Converter):
 
         # generate top level methods defining allowed conversions
         conversions = [('inchikey', 'inchi', 'from_inchikey'),
-                       ('inchikey', 'name', 'from_inchikey'),
+                       ('inchikey', 'compound_name', 'from_inchikey'),
                        ('inchikey', 'iupac_name', 'from_inchikey')]
         self.create_top_level_conversion_methods(conversions)
 
@@ -40,7 +40,7 @@ class CTS(Converter):
         if response:
             return self.parse_inchikey(response)
 
-    async def name_to_inchikey(self, name):
+    async def compound_name_to_inchikey(self, name):
         """
         Convert Chemical name to InChiKey using CTS service
 
@@ -96,7 +96,7 @@ class CTS(Converter):
 
             names = [item['name'] for item in synonyms if item['type'] == 'Synonym']
             if names:
-                result['name'] = names[0]
+                result['compound_name'] = names[0]
 
             names = [item['name'] for item in synonyms if item['type'] == 'IUPAC Name (Preferred)']
             if names:

--- a/MSMetaEnhancer/libs/services/IDSM.py
+++ b/MSMetaEnhancer/libs/services/IDSM.py
@@ -26,11 +26,11 @@ class IDSM(Converter):
                            {'code': 'isomeric_smiles', 'label': 'CHEMINF_000379'}]
 
         # generate top level methods defining allowed conversions
-        conversions = [('name', 'inchi', 'from_name'),
-                       ('name', 'iupac_name', 'from_name'),
-                       ('name', 'formula', 'from_name'),
-                       ('name', 'canonical_smiles', 'from_name'),
-                       ('name', 'isomeric_smiles', 'from_name'),
+        conversions = [('compound_name', 'inchi', 'from_name'),
+                       ('compound_name', 'iupac_name', 'from_name'),
+                       ('compound_name', 'formula', 'from_name'),
+                       ('compound_name', 'canonical_smiles', 'from_name'),
+                       ('compound_name', 'isomeric_smiles', 'from_name'),
                        ('inchi', 'iupac_name', 'from_inchi'),
                        ('inchi', 'formula', 'from_inchi'),
                        ('inchi', 'canonical_smiles', 'from_inchi'),

--- a/MSMetaEnhancer/libs/services/IDSM.py
+++ b/MSMetaEnhancer/libs/services/IDSM.py
@@ -40,7 +40,7 @@ class IDSM(Converter):
         # used to limit the maximal number of simultaneous requests being processed
         self.semaphore = asyncio.Semaphore(10)
 
-    async def name_to_inchikey(self, name):
+    async def compound_name_to_inchikey(self, name):
         """
         Convert Chemical name to InChIKey using IDSM service
 

--- a/MSMetaEnhancer/libs/services/NLM.py
+++ b/MSMetaEnhancer/libs/services/NLM.py
@@ -21,16 +21,16 @@ class NLM(Converter):
 
         self.attributes = [{'code': 'casno', 'label': 'RN / ID'},
                            {'code': 'inchikey', 'label': 'InChIKey'},
-                           {'code': 'name', 'label': 'Name'},
+                           {'code': 'compound_name', 'label': 'Name'},
                            {'code': 'formula', 'label': 'Formula'}]
 
         # generate top level methods defining allowed conversions
-        conversions = [('inchikey', 'name', 'from_inchikey'),
+        conversions = [('inchikey', 'compound_name', 'from_inchikey'),
                        ('inchikey', 'formula', 'from_inchikey'),
                        ('inchikey', 'casno', 'from_inchikey'),
-                       ('name', 'inchikey', 'from_name'),
-                       ('name', 'formula', 'from_name'),
-                       ('name', 'casno', 'from_name')]
+                       ('compound_name', 'inchikey', 'from_name'),
+                       ('compound_name', 'formula', 'from_name'),
+                       ('compound_name', 'casno', 'from_name')]
         self.create_top_level_conversion_methods(conversions)
 
     async def from_inchikey(self, inchikey):

--- a/MSMetaEnhancer/libs/services/PubChem.py
+++ b/MSMetaEnhancer/libs/services/PubChem.py
@@ -1,0 +1,86 @@
+import json
+
+from MSMetaEnhancer.libs.services.Converter import Converter
+from frozendict import frozendict
+
+
+class PubChem(Converter):
+    """
+    PubChem is the world's largest collection of freely accessible chemical information.
+
+    PubChem service: https://pubchem.ncbi.nlm.nih.gov/
+    """
+    def __init__(self, session):
+        super().__init__(session)
+        # service URLs
+        self.services = {'PubChem': 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/'}
+
+        self.attributes = [{'code': 'inchi', 'label': 'InChI', 'extra': None},
+                           {'code': 'inchikey', 'label': 'InChIKey', 'extra': None},
+                           {'code': 'iupac_name', 'label': 'IUPAC Name', 'extra': 'Preferred'},
+                           {'code': 'formula', 'label': 'Molecular Formula', 'extra': None},
+                           {'code': 'canonical_smiles', 'label': 'SMILES', 'extra': 'Canonical'},
+                           {'code': 'isomeric_smiles', 'label': 'SMILES', 'extra': 'Isomeric'}]
+
+        # generate top level methods defining allowed conversions
+        conversions = [('compound_name', 'inchi', 'from_name'),
+                       ('compound_name', 'inchikey', 'from_name'),
+                       ('compound_name', 'iupac_name', 'from_name'),
+                       ('compound_name', 'formula', 'from_name'),
+                       ('compound_name', 'canonical_smiles', 'from_name'),
+                       ('compound_name', 'isomeric_smiles', 'from_name'),
+                       ('inchi', 'inchikey', 'from_inchi'),
+                       ('inchi', 'iupac_name', 'from_inchi'),
+                       ('inchi', 'formula', 'from_inchi'),
+                       ('inchi', 'canonical_smiles', 'from_inchi'),
+                       ('inchi', 'isomeric_smiles', 'from_inchi')]
+        self.create_top_level_conversion_methods(conversions)
+
+    async def from_name(self, name):
+        """
+        Convert Chemical name to all possible attributes using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param name: given Chemical name
+        :return: all found data
+        """
+        args = f'name/{name}/JSON'
+        response = await self.query_the_service('PubChem', args)
+        if response:
+            return self.parse_attributes(response)
+
+    async def from_inchi(self, inchi):
+        """
+        Convert InChi to to all possible attributes using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param inchi: given InChi
+        :return: all found data
+        """
+        args = "inchi/JSON"
+        response = await self.query_the_service('PubChem', args, method='POST', data=frozendict({'inchi': inchi}))
+        if response:
+            return self.parse_attributes(response)
+
+    def parse_attributes(self, response):
+        """
+        Parse all available attributes (specified in self.attributes) from given response.
+
+        Method does not return anything, instead stores data in local cache.
+
+        :param response: given JSON
+        :return: all parsed data
+        """
+        response_json = json.loads(response)
+        result = dict()
+
+        for prop in response_json['PC_Compounds'][0]['props']:
+            label = prop['urn']['label']
+            for att in self.attributes:
+                if label == att['label']:
+                    if att['extra']:
+                        if prop['urn']['name'] == att['extra']:
+                            result[att['code']] = prop['value']['sval']
+                    else:
+                        result[att['code']] = prop['value']['sval']
+        return result

--- a/MSMetaEnhancer/libs/services/__init__.py
+++ b/MSMetaEnhancer/libs/services/__init__.py
@@ -2,5 +2,6 @@ from MSMetaEnhancer.libs.services.CIR import CIR
 from MSMetaEnhancer.libs.services.CTS import CTS
 from MSMetaEnhancer.libs.services.NLM import NLM
 from MSMetaEnhancer.libs.services.IDSM import IDSM
+from MSMetaEnhancer.libs.services.PubChem import PubChem
 
-__all__ = ['IDSM', 'CTS', 'CIR', 'NLM']
+__all__ = ['IDSM', 'CTS', 'CIR', 'NLM', 'PubChem']

--- a/MSMetaEnhancer/libs/utils/Throttler.py
+++ b/MSMetaEnhancer/libs/utils/Throttler.py
@@ -1,0 +1,54 @@
+import asyncio
+import time
+from collections import deque
+from typing import Deque
+
+
+class Throttler:
+    """
+    Class to limit number of parallel requests by a rate (number per period of time).
+    """
+    def __init__(self, rate_limit=10, period=1, retry_interval=0.01):
+        self.rate = rate_limit
+        self.rate_limit = rate_limit
+        self.period = period
+        self.retry_interval = retry_interval
+
+        self._task_logs: Deque[float] = deque()
+
+    def increase_limit(self):
+        """
+        Increase rate up to allow limit.
+        """
+        if self.rate < self.rate_limit:
+            self.rate += 1
+
+    def decrease_limit(self):
+        """
+        Decrease rate (must be always positive).
+        """
+        if self.rate > 0:
+            self.rate -= 1
+
+    def flush(self):
+        now = time.monotonic()
+        while self._task_logs:
+            if now - self._task_logs[0] > self.period:
+                self._task_logs.popleft()
+            else:
+                break
+
+    async def acquire(self):
+        while True:
+            self.flush()
+            if len(self._task_logs) < self.rate:
+                break
+            await asyncio.sleep(self.retry_interval)
+
+        self._task_logs.append(time.monotonic())
+
+    async def __aenter__(self):
+        await self.acquire()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs](https://readthedocs.org/projects/msmetaenhancer/badge/?version=latest)](https://msmetaenhancer.readthedocs.io/en/latest/)
 
 **MSMetaEnhancer** is a tool used for `.msp` files annotation.
-It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), and [IDSM](https://idsm.elixir-czech.cz/).
+It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), [PubChem](https://pubchem.ncbi.nlm.nih.gov/), and [IDSM](https://idsm.elixir-czech.cz/).
 The app uses asynchronous implementation of annotation process allowing for optimal fetching speed.
 
 ### Usage
@@ -23,7 +23,7 @@ app.load_spectra('tests/test_data/sample.msp', file_format='msp')
 app.curate_spectra()
 
 # specify requested services (these are supported)
-services = ['CTS', 'CIR', 'NLM', 'IDSM']
+services = ['CTS', 'CIR', 'NLM', 'IDSM', 'PubChem']
 
 # specify requested jobs
 jobs = [('name', 'inchi', 'IDSM'), ('inchi', 'formula', 'IDSM'), ('inchi', 'inchikey', 'IDSM'),

--- a/docs/source/MSMetaEnhancer.libs.services.rst
+++ b/docs/source/MSMetaEnhancer.libs.services.rst
@@ -30,6 +30,15 @@ IDSM
    :undoc-members:
    :show-inheritance:
 
+PubChem
+-------
+
+.. automodule:: MSMetaEnhancer.libs.services.PubChem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: MSMetaEnhancer.libs.services.Converter
    :members:
    :undoc-members:

--- a/docs/source/MSMetaEnhancer.libs.utils.rst
+++ b/docs/source/MSMetaEnhancer.libs.utils.rst
@@ -29,3 +29,11 @@ Errors
    :members:
    :undoc-members:
    :show-inheritance:
+
+Throttler
+---------
+
+.. automodule:: MSMetaEnhancer.libs.utils.Throttler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -28,4 +28,4 @@ def test_format(value, size):
 
 def test_get_conversions():
     jobs = CTS(None).get_conversion_functions()
-    assert ("inchikey", "name", "CTS") in jobs
+    assert ("inchikey", "compound_name", "CTS") in jobs

--- a/tests/test_NLM.py
+++ b/tests/test_NLM.py
@@ -9,7 +9,7 @@ from tests.utils import wrap_with_session
 
 @pytest.mark.dependency()
 def test_service_available():
-    asyncio.run(wrap_with_session(NLM, 'inchikey_to_name', ['QNAYBMKLOCPYGJ-REOHCLBHSA-N']))
+    asyncio.run(wrap_with_session(NLM, 'inchikey_to_compound_name', ['QNAYBMKLOCPYGJ-REOHCLBHSA-N']))
 
 
 @pytest.mark.dependency(depends=["test_service_available"])
@@ -24,4 +24,4 @@ def test_format():
 
 def test_get_conversions():
     jobs = NLM(None).get_conversion_functions()
-    assert ("name", "inchikey", "NLM") in jobs
+    assert ("compound_name", "inchikey", "NLM") in jobs

--- a/tests/test_PubChem.py
+++ b/tests/test_PubChem.py
@@ -1,0 +1,38 @@
+import asyncio
+import json
+import pytest
+
+from MSMetaEnhancer.libs.services.PubChem import PubChem
+from frozendict import frozendict
+
+from tests.utils import wrap_with_session
+
+
+INCHI = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
+
+
+@pytest.mark.dependency()
+def test_service_available():
+    asyncio.run(wrap_with_session(PubChem, 'inchi_to_inchikey', [INCHI]))
+
+
+@pytest.mark.dependency(depends=["test_service_available"])
+def test_format():
+    inchi = 'InChI=1S/C9H10O4/c10-7-3-1-6(2-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
+    data = frozendict({'inchi': inchi})
+
+    response = asyncio.run(wrap_with_session(PubChem, 'query_the_service',
+                                             ['PubChem', 'inchi/JSON', 'POST', frozendict(data)]))
+    response_json = json.loads(response)
+    assert 'PC_Compounds' in response_json
+    assert len(response_json['PC_Compounds']) > 0
+    assert 'props' in response_json['PC_Compounds'][0]
+
+
+def test_get_conversions():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    jobs = PubChem(None).get_conversion_functions()
+    loop.close()
+
+    assert ('inchi', 'iupac_name', 'PubChem') in jobs

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -8,9 +8,11 @@ from MSMetaEnhancer.libs.utils.Job import Job
 
 
 @pytest.mark.parametrize('data, expected, repeat, mocked', [
-    [{'name': '$NAME'}, {'name': '$NAME', 'inchi': '$InChi'}, False, [({'name': '$NAME', 'inchi': '$InChi'}, None)]],
-    [{'name': '$NAME'}, {'name': '$NAME', 'inchi': '$InChi', 'smiles': '$SMILES'}, True,
-     [({'name': '$NAME', 'inchi': '$InChi'}, None), ({'name': '$NAME', 'inchi': '$InChi', 'smiles': '$SMILES'}, None)]]
+    [{'compound_name': '$NAME'}, {'compound_name': '$NAME', 'inchi': '$InChi'}, False,
+     [({'compound_name': '$NAME', 'inchi': '$InChi'}, None)]],
+    [{'compound_name': '$NAME'}, {'compound_name': '$NAME', 'inchi': '$InChi', 'smiles': '$SMILES'}, True,
+     [({'compound_name': '$NAME', 'inchi': '$InChi'}, None),
+      ({'compound_name': '$NAME', 'inchi': '$InChi', 'smiles': '$SMILES'}, None)]]
 ])
 def test_annotate(data, expected, repeat, mocked):
     jobs = [Job(('inchi', 'smiles', 'IDSM')),


### PR DESCRIPTION
This PR implements `PubChem` service again using direct access to `PubChem` REST [API](https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest).
This also required to use throttling as there are strict [limitations](https://pubchemdocs.ncbi.nlm.nih.gov/programmatic-access$_requestvolumelimitations) on the frequency of requests. It can dynamically change the current request rate by reading the current load information of the API provided by the response [header](https://pubchemdocs.ncbi.nlm.nih.gov/dynamic-request-throttling).