### PR TITLE
Improved parsing of PubChem response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dev] - unreleased
 ### Added
 ### Changed
+* improved parsing of PubChem responses [#84](https://github.com/RECETOX/MSMetaEnhancer/issues/84)
 ### Removed
 
 ## [0.2.0] - 2022-03-19

--- a/MSMetaEnhancer/libs/converters/web/PubChem.py
+++ b/MSMetaEnhancer/libs/converters/web/PubChem.py
@@ -177,15 +177,21 @@ class PubChem(WebConverter):
         response_json = json.loads(response)
         result = dict()
 
-        result['pubchemid'] = response_json['PC_Compounds'][0]['id']['id']['cid']
+        if 'PC_Compounds' in response_json:
+            if len(response_json['PC_Compounds']) > 0:
+                first_hit = response_json['PC_Compounds'][0]
 
-        for prop in response_json['PC_Compounds'][0]['props']:
-            label = prop['urn']['label']
-            for att in self.attributes:
-                if label == att['label']:
-                    if att['extra']:
-                        if prop['urn']['name'] == att['extra']:
-                            result[att['code']] = prop['value']['sval']
-                    else:
-                        result[att['code']] = prop['value']['sval']
+                pubchemid = first_hit.get('id', {}).get('id', {}).get('cid', None)
+                if pubchemid:
+                    result['pubchemid'] = pubchemid
+
+                for prop in first_hit.get('props', {}):
+                    label = prop['urn']['label']
+                    for att in self.attributes:
+                        if label == att['label']:
+                            if att['extra']:
+                                if prop['urn']['name'] == att['extra']:
+                                    result[att['code']] = prop['value']['sval']
+                            else:
+                                result[att['code']] = prop['value']['sval']
         return result

--- a/tests/test_PubChem.py
+++ b/tests/test_PubChem.py
@@ -36,3 +36,14 @@ def test_get_conversions():
     loop.close()
 
     assert ('inchi', 'iupac_name', 'PubChem') in jobs
+
+
+@pytest.mark.parametrize('response, expected', [
+    [{"PC_Compounds": [{"id": {"id": {"cid": "123"}},
+                        "props": [{"urn": {"label": "InChI"}, "value": {"sval": "random_inchi"}}]}]},
+     {"pubchemid": "123", "inchi": "random_inchi"}],
+    [{"PC_Compounds": [{"id": {}, "props": []}]}, dict()]
+])
+def test_parse_attributes(response, expected):
+    actual = PubChem(None).parse_attributes(json.dumps(response))
+    assert actual == expected


### PR DESCRIPTION
This PR improves parsing of `PubChem` query response, as in the cases when there are no successful hits, the response still has status code `200`, the response even has the same structure, but there is no data.

Close #84.