### PR TITLE
Log unknown errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Added
+* logging of unknown errors in Annotator [#90](https://github.com/RECETOX/MSMetaEnhancer/issues/90) 
 ### Changed
 ### Removed
 

--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -1,7 +1,7 @@
 from MSMetaEnhancer.libs.Curator import Curator
 from MSMetaEnhancer.libs.utils import logger
-from MSMetaEnhancer.libs.utils.Errors import ConversionNotSupported, TargetAttributeNotRetrieved, \
-    SourceAttributeNotAvailable, ServiceNotAvailable, UnknownResponse, UnknownError
+from MSMetaEnhancer.libs.utils.Errors import TargetAttributeNotRetrieved, SourceAttributeNotAvailable, \
+    ServiceNotAvailable
 from MSMetaEnhancer.libs.utils.Logger import LogWarning
 
 

--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -43,17 +43,12 @@ class Annotator:
                         metadata, cache = await self.execute_job_with_cache(job, metadata, cache, warning)
                         if repeat:
                             added_metadata = True
-                    except (ConversionNotSupported, TargetAttributeNotRetrieved, UnknownResponse) as exc:
-                        warning.add_warning(exc)
                     except SourceAttributeNotAvailable as exc:
                         warning.add_info(exc)
-                    except ServiceNotAvailable:
-                        warning.add_warning(ServiceNotAvailable(f'Service {job.converter} not available.'))
-                    except Exception as e:
-                        logger.error(UnknownError(e))
+                    except Exception as exc:
+                        warning.add_warning(type(exc)((f'{job}:\n' + str(exc))))
                 else:
-                    warning.add_info(f'Conversion ({job.converter}) {job.source} -> {job.target}: Requested '
-                                     f'attribute {job.target} already present in given metadata.')
+                    warning.add_info(f'{job}: Requested attribute {job.target} already present in given metadata.')
 
         logger.add_warning(warning)
         logger.add_coverage_after(metadata.keys())
@@ -88,7 +83,7 @@ class Annotator:
                 if job.target in cache[job.converter]:
                     metadata[job.target] = cache[job.converter][job.target]
                 else:
-                    raise TargetAttributeNotRetrieved(f'{job} - conversion retrieved no data.')
+                    raise TargetAttributeNotRetrieved(f'No data retrieved.')
             else:
-                raise ServiceNotAvailable
+                raise ServiceNotAvailable(f'Service {job.converter} not available.')
         return metadata, cache

--- a/MSMetaEnhancer/libs/Annotator.py
+++ b/MSMetaEnhancer/libs/Annotator.py
@@ -1,7 +1,7 @@
 from MSMetaEnhancer.libs.Curator import Curator
 from MSMetaEnhancer.libs.utils import logger
 from MSMetaEnhancer.libs.utils.Errors import ConversionNotSupported, TargetAttributeNotRetrieved, \
-    SourceAttributeNotAvailable, ServiceNotAvailable, UnknownResponse
+    SourceAttributeNotAvailable, ServiceNotAvailable, UnknownResponse, UnknownError
 from MSMetaEnhancer.libs.utils.Logger import LogWarning
 
 
@@ -49,6 +49,8 @@ class Annotator:
                         warning.add_info(exc)
                     except ServiceNotAvailable:
                         warning.add_warning(ServiceNotAvailable(f'Service {job.converter} not available.'))
+                    except Exception as e:
+                        logger.error(UnknownError(e))
                 else:
                     warning.add_info(f'Conversion ({job.converter}) {job.source} -> {job.target}: Requested '
                                      f'attribute {job.target} already present in given metadata.')

--- a/MSMetaEnhancer/libs/Curator.py
+++ b/MSMetaEnhancer/libs/Curator.py
@@ -68,7 +68,7 @@ class Curator:
                     valid_metadata[attribute] = value
                 else:
                     warning.add_warning(
-                        InvalidAttributeFormat(f'Job {job} obtained {attribute} in invalid format: {value}'))
+                        InvalidAttributeFormat(f'{job}:\n Obtained {attribute} in invalid format: {value}'))
             else:
                 valid_metadata[attribute] = value
         return valid_metadata

--- a/MSMetaEnhancer/libs/converters/web/PubChem.py
+++ b/MSMetaEnhancer/libs/converters/web/PubChem.py
@@ -125,7 +125,8 @@ class PubChem(WebConverter):
         :return: processed response
         """
         result = await response.text()
-        self.adjust_throttling(response.headers['X-Throttling-Control'])
+        if 'X-Throttling-Control' in response.headers:
+            self.adjust_throttling(response.headers['X-Throttling-Control'])
         if response.ok:
             return result
         else:

--- a/MSMetaEnhancer/libs/converters/web/WebConverter.py
+++ b/MSMetaEnhancer/libs/converters/web/WebConverter.py
@@ -24,8 +24,7 @@ class WebConverter(Converter):
         if result:
             return result
         else:
-            raise TargetAttributeNotRetrieved(f'{self.converter_name}: {source} -> {target} '
-                                              f'- conversion retrieved no data.')
+            raise TargetAttributeNotRetrieved(f'No data retrieved.')
 
     @lru_cache
     async def query_the_service(self, service, args, method='GET', data=None, headers=None):
@@ -72,7 +71,7 @@ class WebConverter(Converter):
                 logger.error(ServiceNotAvailable(f'Service {self.converter_name} '
                                                  f'temporarily unavailable, trying again...'))
                 return await self.loop_request(url, method, data, headers, depth - 1)
-            raise ServiceNotAvailable
+            raise ServiceNotAvailable(f'Service {self.converter_name} not available.')
 
     async def process_request(self, response, url, method):
         """

--- a/MSMetaEnhancer/libs/utils/Errors.py
+++ b/MSMetaEnhancer/libs/utils/Errors.py
@@ -28,3 +28,7 @@ class UnknownResponse(Exception):
 
 class InvalidAttributeFormat(Exception):
     pass
+
+
+class UnknownError(Exception):
+    pass

--- a/MSMetaEnhancer/libs/utils/Errors.py
+++ b/MSMetaEnhancer/libs/utils/Errors.py
@@ -28,7 +28,3 @@ class UnknownResponse(Exception):
 
 class InvalidAttributeFormat(Exception):
     pass
-
-
-class UnknownError(Exception):
-    pass

--- a/MSMetaEnhancer/libs/utils/Job.py
+++ b/MSMetaEnhancer/libs/utils/Job.py
@@ -26,8 +26,7 @@ class Job:
             raise ConversionNotSupported(f'Conversion ({self.converter}) {self.source} -> {self.target}: '
                                          f'is not supported')
         elif data is None:
-            raise SourceAttributeNotAvailable(f'Conversion ({self.converter}) {self.source} -> {self.target}: '
-                                              f'Attribute {self.source} missing in given metadata.')
+            raise SourceAttributeNotAvailable(f'{self}:\n Attribute {self.source} missing in given metadata.')
         else:
             return converter, data
 

--- a/MSMetaEnhancer/libs/utils/Logger.py
+++ b/MSMetaEnhancer/libs/utils/Logger.py
@@ -143,7 +143,7 @@ class LogWarning:
 
         :param exc: given exception
         """
-        self.warnings.append({'level': 2, 'msg': f'-> {exc}'})
+        self.warnings.append({'level': 2, 'msg': f'-> {type(exc).__name__} - {exc}'})
 
     def add_info(self, info):
         """
@@ -151,4 +151,4 @@ class LogWarning:
 
         :param info: given info message
         """
-        self.warnings.append({'level': 1, 'msg': f'-> {info}'})
+        self.warnings.append({'level': 1, 'msg': f'-> {type(info).__name__} - {info}'})

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Conda](https://img.shields.io/conda/v/bioconda/msmetaenhancer)](https://anaconda.org/bioconda/msmetaenhancer)
 
 **MSMetaEnhancer** is a tool used for `.msp` files annotation.
-It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), [PubChem](https://pubchem.ncbi.nlm.nih.gov/), and [IDSM](https://idsm.elixir-czech.cz/).
+It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), [PubChem](https://pubchem.ncbi.nlm.nih.gov/), [IDSM](https://idsm.elixir-czech.cz/), and [BridgeDB](https://bridgedb.github.io/).
 The app uses asynchronous implementation of annotation process allowing for optimal fetching speed.
 
 ### Usage
@@ -23,8 +23,8 @@ app.load_spectra('tests/test_data/sample.msp', file_format='msp')
 # curate given metadata (e.g. fix CAS numbers)
 app.curate_spectra()
 
-# specify requested web (these are supported)
-services = ['CTS', 'CIR', 'NLM', 'IDSM', 'PubChem']
+# specify requested services (these are supported)
+services = ['CTS', 'CIR', 'NLM', 'IDSM', 'PubChem', 'BridgeDB', 'RDKit']
 
 # specify requested jobs
 jobs = [('name', 'inchi', 'IDSM'), ('inchi', 'formula', 'IDSM'), ('inchi', 'inchikey', 'IDSM'),

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -75,3 +75,21 @@ def test_execute_job_with_cache():
 
     with pytest.raises(TargetAttributeNotRetrieved):
         metadata, cache = asyncio.run(annotator.execute_job_with_cache(job, {'smiles': '$SMILES'}, dict(), warning))
+
+
+def test_catch_exception():
+    metadata = {'inchi': 'a value', 'compound_name': 'a molecule'}
+    result_metadata = {'inchi': 'a value', 'compound_name': 'a molecule',  'atr1': 'val1',  'atr2': 'val2'}
+    spectra = mock.Mock()
+    spectra.metadata = metadata
+    jobs = [mock.Mock(target='a target')] * 3
+    annotator = Annotator()
+    annotator.set_converters(dict())
+    mocked = [({'inchi': 'a value', 'compound_name': 'a molecule', 'atr1': 'val1'}, dict()),
+              Exception(),
+              (result_metadata, dict())]
+    annotator.execute_job_with_cache = mock.AsyncMock()
+    annotator.execute_job_with_cache.side_effect = mocked
+
+    result = asyncio.run(annotator.annotate(spectra, jobs))
+    assert result.metadata == result_metadata


### PR DESCRIPTION
Currently, many types of errors ranging from connection issues to wrong response format, are carefully detected and logged. However, if there is an unknown exception, the whole annotation run will fail. 

This PR introduces the catching of general `Exception`s in the `Annotator` class to make sure upon an exception, only a single annotation job fails, the particular exception is logged, and the tool continues with other jobs and spectra.

Close #90.