### PR TITLE
Changed double to single quotes in IDSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev] - unreleased
+### Added
+### Changed
+* double quotes to single quotes in IDSM [#102](https://github.com/RECETOX/MSMetaEnhancer/issues/102)
+### Removed
+
 ## [0.2.2] - 2022-04-27
 ### Added
 * introduced `error` level into logging [#95](https://github.com/RECETOX/MSMetaEnhancer/issues/95)

--- a/MSMetaEnhancer/libs/converters/web/IDSM.py
+++ b/MSMetaEnhancer/libs/converters/web/IDSM.py
@@ -55,7 +55,7 @@ class IDSM(WebConverter):
           ?attribute sio:has-value ?value.
           ?compound sio:has-attribute ?attribute.
           ?compound sio:has-attribute ?descriptor.
-          ?descriptor sio:has-value "{iupac_name.lower()}"@en.
+          ?descriptor sio:has-value '{iupac_name.lower()}'@en.
         }}
         """
         return await self.call_service(query)
@@ -75,7 +75,7 @@ class IDSM(WebConverter):
           ?inchikey rdf:type ?type.
           ?inchikey sio:is-attribute-of ?compound.
           ?synonym sio:is-attribute-of ?compound.
-          ?synonym sio:has-value "{name.lower()}"@en.
+          ?synonym sio:has-value '{name.lower()}'@en.
         }}
         """
         return await self.call_service(query)
@@ -95,7 +95,7 @@ class IDSM(WebConverter):
           ?inchikey rdf:type ?type.
           ?inchikey sio:is-attribute-of ?compound.
           ?compound sio:has-attribute ?inchi.
-          ?inchi sio:has-value "{inchi}"@en.
+          ?inchi sio:has-value '{inchi}'@en.
         }}
         """
         return await self.call_service(query)
@@ -115,7 +115,7 @@ class IDSM(WebConverter):
           ?attribute sio:has-value ?value.
           ?compound sio:has-attribute ?attribute.
           ?synonym sio:is-attribute-of ?compound.
-          ?synonym sio:has-value "{name.lower()}"@en.
+          ?synonym sio:has-value '{name.lower()}'@en.
         }}
         """
         return await self.call_service(query)
@@ -135,7 +135,7 @@ class IDSM(WebConverter):
           ?attribute sio:has-value ?value.
           ?compound sio:has-attribute ?attribute.
           ?compound sio:has-attribute ?inchi.
-          ?inchi sio:has-value "{inchi}"@en.
+          ?inchi sio:has-value '{inchi}'@en.
         }}
         """
         return await self.call_service(query)


### PR DESCRIPTION
When both single `'` and double `"` quotes are present in a string, `Python` implicitly escapes the single ones. As a consequence, when formatting strings, they must be placed in single quotes to avoid premature string termination:

Compare incorrect string:

```python
"escaped single \' quote and normal " double quote"
```
with correct string:

```python
'escaped single \' quote and normal " double quote'
```

This was exactly the issue in `IDSM, where SPARQL query was formatted using double quotes. This PR changed it to single quotes.

Close #102.