### PR TITLE
Escape single quotes in IDSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dev] - unreleased
 ### Added
 ### Changed
+* escaping of single quotes in IDSM arguments [#102](https://github.com/RECETOX/MSMetaEnhancer/issues/102)
 ### Removed
 
 ## [0.2.3] - 2022-05-12

--- a/MSMetaEnhancer/libs/converters/web/IDSM.py
+++ b/MSMetaEnhancer/libs/converters/web/IDSM.py
@@ -3,7 +3,7 @@ import asyncio
 from MSMetaEnhancer.libs.converters.web.WebConverter import WebConverter
 from frozendict import frozendict
 
-from MSMetaEnhancer.libs.utils.Generic import escape_arg
+from MSMetaEnhancer.libs.utils.Generic import escape_single_quotes
 
 
 class IDSM(WebConverter):
@@ -42,7 +42,7 @@ class IDSM(WebConverter):
         # used to limit the maximal number of simultaneous requests being processed
         self.semaphore = asyncio.Semaphore(10)
 
-    @escape_arg
+    @escape_single_quotes
     async def iupac_name_to_inchi(self, iupac_name):
         """
         Convert IUPAC name to InChI using IDSM service
@@ -63,7 +63,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
-    @escape_arg
+    @escape_single_quotes
     async def compound_name_to_inchikey(self, name):
         """
         Convert Chemical name to InChIKey using IDSM service
@@ -84,7 +84,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
-    @escape_arg
+    @escape_single_quotes
     async def inchi_to_inchikey(self, inchi):
         """
         Convert InChi to InChIKey using IDSM service
@@ -105,7 +105,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
-    @escape_arg
+    @escape_single_quotes
     async def from_name(self, name):
         """
         Convert Chemical name to all possible attributes using IDSM service
@@ -126,7 +126,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
-    @escape_arg
+    @escape_single_quotes
     async def from_inchi(self, inchi):
         """
         Convert InChi to to all possible attributes using IDSM service

--- a/MSMetaEnhancer/libs/converters/web/IDSM.py
+++ b/MSMetaEnhancer/libs/converters/web/IDSM.py
@@ -3,6 +3,8 @@ import asyncio
 from MSMetaEnhancer.libs.converters.web.WebConverter import WebConverter
 from frozendict import frozendict
 
+from MSMetaEnhancer.libs.utils.Generic import escape_arg
+
 
 class IDSM(WebConverter):
     """
@@ -40,6 +42,7 @@ class IDSM(WebConverter):
         # used to limit the maximal number of simultaneous requests being processed
         self.semaphore = asyncio.Semaphore(10)
 
+    @escape_arg
     async def iupac_name_to_inchi(self, iupac_name):
         """
         Convert IUPAC name to InChI using IDSM service
@@ -60,6 +63,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
+    @escape_arg
     async def compound_name_to_inchikey(self, name):
         """
         Convert Chemical name to InChIKey using IDSM service
@@ -80,6 +84,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
+    @escape_arg
     async def inchi_to_inchikey(self, inchi):
         """
         Convert InChi to InChIKey using IDSM service
@@ -100,6 +105,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
+    @escape_arg
     async def from_name(self, name):
         """
         Convert Chemical name to all possible attributes using IDSM service
@@ -120,6 +126,7 @@ class IDSM(WebConverter):
         """
         return await self.call_service(query)
 
+    @escape_arg
     async def from_inchi(self, inchi):
         """
         Convert InChi to to all possible attributes using IDSM service

--- a/MSMetaEnhancer/libs/utils/Generic.py
+++ b/MSMetaEnhancer/libs/utils/Generic.py
@@ -1,4 +1,4 @@
-def escape_arg(f):
+def escape_single_quotes(f):
     async def wrapper(self, arg):
         return await f(self, arg.replace("'", "\\'"))
     return wrapper

--- a/MSMetaEnhancer/libs/utils/Generic.py
+++ b/MSMetaEnhancer/libs/utils/Generic.py
@@ -1,0 +1,4 @@
+def escape_arg(f):
+    async def wrapper(self, arg):
+        return await f(self, arg.replace("'", "\\'"))
+    return wrapper


### PR DESCRIPTION
This PR targets issue #102, which was partially solved in #103.

There are four options regarding quotes - a string contains (1) both of them, (2) only single, (3) only double, or (4) no quotes. While #103 fixed the first case, it introduced errors for case (2). The quotes are not escaped implicitly in this case, and because the `compound_name` or `inchi` are enclosed by single quotes, it causes premature string termination.

As a solution, I added decorator `escape_single_quotes` which _always_ escapes single quotes in a string for IDSM service.

Close #102.