### PR TITLE
Remove misleading code from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ jobs = [('name', 'inchi', 'IDSM'), ('inchi', 'formula', 'IDSM'), ('inchi', 'inch
 # run asynchronous annotations of spectra data
 asyncio.run(app.annotate_spectra(services, jobs))
 
-# execute without jobs parameter to run all possible jobs
-asyncio.run(app.annotate_spectra(services))
-
 # export .msp file 
 app.save_spectra('tests/test_data/sample_out.msp', file_format='msp')
 ```


### PR DESCRIPTION
It is not possible to call `Application.annotate_spectra` twice as it was in README. The reason for that is the `Monitor` thread (monitor the availability of web services), that was already run and joined. A possible workaround is to pass a new instance `Monitor` of as argument `monitor`.

```python
asyncio.run(app.annotate_spectra(services, monitor=Monitor()))
```

To avoid confusion and simplify things, I removed the second call.

Close #116.