### PR TITLE
Update Curator tests 

### DIFF
--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -12,8 +12,6 @@ def test_fix_cas_number():
 
 
 @pytest.mark.parametrize('metadata, validated_metadata, logs_size', [
-    [{'formula': 'CH4', 'smiles': 'C', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'},
-     {'formula': 'CH4', 'iupac_name': 'methane', 'inchi': 'InChI=1S/CH4/h1H4'}, 1],
     [{'inchikey': '<html>random content</html>'}, {}, 1],
     [{'smiles': 'CC(NC(C)=O)C#N'}, {'smiles': 'CC(NC(C)=O)C#N'}, 0]
 ])


### PR DESCRIPTION
With `matchms` version `0.16.0`, an [updated](https://github.com/matchms/matchms/pull/337) regex for checking SMILES was employed. This makes smiles such as `'C'` valid and one test in `Curator` obsolete. I removed it in this PR.

Close #112.