### PR TITLE
Change order of entries in docs front page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,8 @@ sys.path.insert(0, os.path.abspath('../../'))
 import MSMetaEnhancer
 from shutil import copyfile
 copyfile('../../README.md', 'readme.md')
-copyfile('../../CHANGELOG.md', 'changelog.md')
+copyfile('../../CHANGELOG.md', 'CHANGELOG.md')
+copyfile('../../CONTRIBUTING.md', 'CONTRIBUTING.md')
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Welcome to MSMetaEnhancer's documentation!
 
    Documentation <MSMetaEnhancer>
    Readme <readme>
-   changelog
+   CHANGELOG
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,8 +9,8 @@ Welcome to MSMetaEnhancer's documentation!
 .. toctree::
    :maxdepth: 1
 
-   Documentation <MSMetaEnhancer>
    Readme <readme>
+   Documentation <MSMetaEnhancer>
    CHANGELOG
 
 Indices and tables


### PR DESCRIPTION
As suggested in JOSS review #114, it can be easier for a newcomer to see `readme` before `API docs`.

Close #114.