### PR TITLE
Fix async tests

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -34,7 +34,6 @@ def test_query_the_service():
     converter.loop_request.assert_not_called()
 
 
-@pytest.fixture
 async def test_loop_request(aiohttp_client):
     response = {'smiles': '$SMILES'}
 
@@ -54,7 +53,6 @@ async def test_loop_request(aiohttp_client):
     assert result == response
 
 
-@pytest.fixture
 async def test_loop_request_fail(aiohttp_client):
     async def fake_request(request):
         raise ServerDisconnectedError()
@@ -140,7 +138,6 @@ def test_convert():
         _ = asyncio.run(converter.convert('B', 'C', None))
 
 
-@pytest.fixture
 async def test_lru_cache(aiohttp_client):
     def create_app(loop):
         app = web.Application(loop=loop)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -77,6 +77,7 @@ def failing_session_mock(request):
     yield session
 
 
+@pytest.mark.asyncio
 async def test_loop_request_circuit_breaker_get(failing_session_mock):
     converter = WebConverter(failing_session_mock)
 
@@ -84,6 +85,7 @@ async def test_loop_request_circuit_breaker_get(failing_session_mock):
         await converter.loop_request('/', 'GET', None, None)
 
 
+@pytest.mark.asyncio
 async def test_loop_request_circuit_breaker_post(failing_session_mock):
     converter = WebConverter(failing_session_mock)
     data = {'inchi': 'inchi'}
@@ -138,6 +140,7 @@ def test_convert():
         _ = asyncio.run(converter.convert('B', 'C', None))
 
 
+@pytest.mark.asyncio
 async def test_lru_cache(aiohttp_client):
     def create_app(loop):
         app = web.Application(loop=loop)


### PR DESCRIPTION
Avoid skipping async tests from `test_converter.py` in CI

- reverted [9cc54bf](https://github.com/RECETOX/MSMetaEnhancer/pull/123/commits/9cc54bf5e58464df54a439c936db82d21ba86f62) because the tests decorated with `@pytest.fixture` aren't treated as tests and thus aren't executed