### PR TITLE
Fix Circuit Breaker pattern in python 3.9; fix skipping async tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Added
+* added Pytest config file `pytest.ini` and set it to automatically detect asynchronous tests [#124](https://github.com/RECETOX/MSMetaEnhancer/pull/124)
 ### Changed
+* fixed Circuit Breaker implementation to be compatible with Python 3.9 [#124](https://github.com/RECETOX/MSMetaEnhancer/pull/124)
 ### Removed
 
 ## [0.2.4] - 2022-08-30

--- a/MSMetaEnhancer/libs/converters/web/WebConverter.py
+++ b/MSMetaEnhancer/libs/converters/web/WebConverter.py
@@ -68,7 +68,7 @@ class WebConverter(Converter):
             raise TypeError(f'Incorrect argument {args} for converter {service}.')
 
     @circuit(failure_threshold=FAILURE_THRESHOLD,
-             expected_exception=Union[TimeoutError, ServerDisconnectedError, ClientConnectorError],
+             expected_exception=Union[TimeoutError, ServerDisconnectedError, ClientConnectorError].__args__,
              fallback_function=ServiceNotAvailable.raise_circuitbreaker)
     async def make_request(self, url, method, data, headers):
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -37,15 +37,13 @@ def test_query_the_service():
 async def test_loop_request(aiohttp_client):
     response = {'smiles': '$SMILES'}
 
-    async def fake_request(request):
+    async def fake_request():
         return web.Response(body=response)
 
-    def create_app(loop):
-        app = web.Application(loop=loop)
-        app.router.add_route('GET', '/', fake_request)
-        return app
+    app = web.Application()
+    app.router.add_route('GET', '/', fake_request)
 
-    session = await aiohttp_client(create_app)
+    session = await aiohttp_client(app)
     converter = WebConverter(session)
     converter.process_request = mock.AsyncMock(return_value=response)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -139,11 +139,9 @@ def test_convert():
 
 
 async def test_lru_cache(aiohttp_client):
-    def create_app(loop):
-        app = web.Application(loop=loop)
-        return app
+    app = web.Application()
 
-    session = await aiohttp_client(create_app)
+    session = await aiohttp_client(app)
     converter = WebConverter(session)
     converter.endpoints = {'/': '/'}
     converter.loop_request = mock.AsyncMock(return_value=(1, 2, 3))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -34,7 +34,6 @@ def test_query_the_service():
     converter.loop_request.assert_not_called()
 
 
-@pytest.fixture
 async def test_loop_request(aiohttp_client):
     response = {'smiles': '$SMILES'}
 
@@ -54,7 +53,6 @@ async def test_loop_request(aiohttp_client):
     assert result == response
 
 
-@pytest.fixture
 async def test_loop_request_fail(aiohttp_client):
     async def fake_request(request):
         raise ServerDisconnectedError()
@@ -140,7 +138,6 @@ def test_convert():
         _ = asyncio.run(converter.convert('B', 'C', None))
 
 
-@pytest.fixture
 async def test_lru_cache(aiohttp_client):
     def create_app(loop):
         app = web.Application(loop=loop)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -52,15 +52,13 @@ async def test_loop_request(aiohttp_client):
 
 
 async def test_loop_request_fail(aiohttp_client):
-    async def fake_request(request):
+    async def fake_request():
         raise ServerDisconnectedError()
 
-    def create_app(loop):
-        app = web.Application(loop=loop)
-        app.router.add_route('GET', '/', fake_request)
-        return app
+    app = web.Application()
+    app.router.add_route('GET', '/', fake_request)
 
-    session = await aiohttp_client(create_app)
+    session = await aiohttp_client(app)
     converter = WebConverter(session)
 
     with pytest.raises(UnknownResponse):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,7 +6,6 @@ from aiohttp import web
 from aiohttp.client_exceptions import ServerDisconnectedError
 from aiohttp import ClientConnectorError
 from asyncio.exceptions import TimeoutError
-import os
 
 from MSMetaEnhancer.libs.converters.web.WebConverter import WebConverter
 from MSMetaEnhancer.libs.utils.Errors import TargetAttributeNotRetrieved, UnknownResponse, ServiceNotAvailable


### PR DESCRIPTION
- reverted 0efde23 since tests decorated with `@pytest.fixture` are not executed
- fixed Circuit Breaker pattern failing in Python 3.9~
- added `pytest.ini` with `async_mode=auto` so that pytest automatically detects async tests (it doesn't by default)