### PR TITLE
Fix Publish to PyPi action

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
It is recommended to enclose versions in quotes in YAML files. The parser treats `python-version: 3.10` as `3.1`. I suspect that's is the reason why `Publish to PyPi` on release `v2.4.0` failed with this error:
```
Error: Version 3.1 with arch x64 not found
```

Source: https://github.com/actions/setup-python/issues/160#issuecomment-724485470