### PR TITLE
Changed BridgeDB references to BridgeDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.3] - 2022-05-12
 ### Added
-* KEGG ID conversions support to BridgeDB service [#101](https://github.com/RECETOX/MSMetaEnhancer/issues/101)
+* KEGG ID conversions support to BridgeDb service [#101](https://github.com/RECETOX/MSMetaEnhancer/issues/101)
 ### Changed
 * double quotes to single quotes in IDSM [#102](https://github.com/RECETOX/MSMetaEnhancer/issues/102)
 
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2022-03-19
 ### Added
-* BridgeDB supporting conversion of several database IDs [#76](https://github.com/RECETOX/MSMetaEnhancer/issues/76)
+* BridgeDb supporting conversion of several database IDs [#76](https://github.com/RECETOX/MSMetaEnhancer/issues/76)
 * ComputeConverter class for conversions based on computation instead of querying [#75](https://github.com/RECETOX/MSMetaEnhancer/issues/75)
 * ConverterBuilder which validates and initialises converters [#75](https://github.com/RECETOX/MSMetaEnhancer/issues/75)
 * reintroduced PubChem service using direct REST web interface [#76](https://github.com/RECETOX/MSMetaEnhancer/issues/76)

--- a/MSMetaEnhancer/libs/converters/web/BridgeDB.py
+++ b/MSMetaEnhancer/libs/converters/web/BridgeDB.py
@@ -11,7 +11,7 @@ class BridgeDb(WebConverter):
     def __init__(self, session):
         super().__init__(session)
         # service URLs
-        self.endpoints = {'BridgeDB': 'https://webservice.bridgedb.org/Human/xrefs/'}
+        self.endpoints = {'BridgeDb': 'https://webservice.bridgedb.org/Human/xrefs/'}
 
         self.codes = {'hmdbid': 'Ch', 'pubchemid': 'Cpc', 'chemspiderid': 'Cs', 'wikidataid': 'Wd', 'chebiid': 'Ce',
                       'keggid': 'Ck'}
@@ -54,7 +54,7 @@ class BridgeDb(WebConverter):
 
     async def from_hmdbid(self, hmdbid):
         """
-        Convert HMDB ID to all possible IDs using BridgeDB web service
+        Convert HMDB ID to all possible IDs using BridgeDb web service
 
         :param hmdbid: given HMDB ID number
         :return: obtained IDs
@@ -64,7 +64,7 @@ class BridgeDb(WebConverter):
 
     async def from_pubchemid(self, pubchemid):
         """
-        Convert PubChem ID to all possible IDs using BridgeDB web service
+        Convert PubChem ID to all possible IDs using BridgeDb web service
 
         :param pubchemid: given PubChem ID number
         :return: obtained IDs
@@ -74,7 +74,7 @@ class BridgeDb(WebConverter):
 
     async def from_chemspiderid(self, chemspiderid):
         """
-        Convert ChemSpider ID to all possible IDs using BridgeDB web service
+        Convert ChemSpider ID to all possible IDs using BridgeDb web service
 
         :param chemspiderid: given ChemSpider ID number
         :return: obtained IDs
@@ -84,7 +84,7 @@ class BridgeDb(WebConverter):
 
     async def from_wikidataid(self, wikidataid):
         """
-        Convert WikiData ID to all possible IDs using BridgeDB web service
+        Convert WikiData ID to all possible IDs using BridgeDb web service
 
         :param wikidataid: given WikiData ID number
         :return: obtained IDs
@@ -94,7 +94,7 @@ class BridgeDb(WebConverter):
 
     async def from_chebiid(self, chebiid):
         """
-        Convert ChEBI ID to all possible IDs using BridgeDB web service
+        Convert ChEBI ID to all possible IDs using BridgeDb web service
 
         :param chebiid: given ChEBI ID number
         :return: obtained IDs
@@ -104,7 +104,7 @@ class BridgeDb(WebConverter):
 
     async def from_keggid(self, keggid):
         """
-        Convert KEGG ID to all possible IDs using BridgeDB web service
+        Convert KEGG ID to all possible IDs using BridgeDb web service
 
         :param keggid: given KEGG ID number
         :return: obtained IDs
@@ -113,15 +113,15 @@ class BridgeDb(WebConverter):
         return await self.call_service(args)
 
     async def call_service(self, args):
-        response = await self.query_the_service('BridgeDB', args)
+        response = await self.query_the_service('BridgeDb', args)
         if response:
             return self.parse_attributes(response)
 
     def parse_attributes(self, response):
         """
-        Parse all available attributes obtained using BridgeDB.
+        Parse all available attributes obtained using BridgeDb.
 
-        :param response: BridgeDB response to given ID
+        :param response: BridgeDb response to given ID
         :return: all parsed data
         """
         result = dict()

--- a/MSMetaEnhancer/libs/converters/web/BridgeDB.py
+++ b/MSMetaEnhancer/libs/converters/web/BridgeDB.py
@@ -1,7 +1,7 @@
 from MSMetaEnhancer.libs.converters.web.WebConverter import WebConverter
 
 
-class BridgeDB(WebConverter):
+class BridgeDb(WebConverter):
     """
     BridgeDb is a framework to map identifiers between various biological databases. These mappings are provided for
     genes, proteins, genetic variants, metabolites, and metabolic reactions

--- a/MSMetaEnhancer/libs/converters/web/__init__.py
+++ b/MSMetaEnhancer/libs/converters/web/__init__.py
@@ -3,6 +3,6 @@ from MSMetaEnhancer.libs.converters.web.CTS import CTS
 from MSMetaEnhancer.libs.converters.web.CIR import CIR
 from MSMetaEnhancer.libs.converters.web.NLM import NLM
 from MSMetaEnhancer.libs.converters.web.PubChem import PubChem
-from MSMetaEnhancer.libs.converters.web.BridgeDB import BridgeDb
+from MSMetaEnhancer.libs.converters.web.BridgeDb import BridgeDb
 
 __all__ = ['IDSM', 'CTS', 'CIR', 'NLM', 'PubChem', 'BridgeDb']

--- a/MSMetaEnhancer/libs/converters/web/__init__.py
+++ b/MSMetaEnhancer/libs/converters/web/__init__.py
@@ -3,6 +3,6 @@ from MSMetaEnhancer.libs.converters.web.CTS import CTS
 from MSMetaEnhancer.libs.converters.web.CIR import CIR
 from MSMetaEnhancer.libs.converters.web.NLM import NLM
 from MSMetaEnhancer.libs.converters.web.PubChem import PubChem
-from MSMetaEnhancer.libs.converters.web.BridgeDb import BridgeDb
+from MSMetaEnhancer.libs.converters.web.BridgeDB import BridgeDb
 
 __all__ = ['IDSM', 'CTS', 'CIR', 'NLM', 'PubChem', 'BridgeDb']

--- a/MSMetaEnhancer/libs/converters/web/__init__.py
+++ b/MSMetaEnhancer/libs/converters/web/__init__.py
@@ -3,6 +3,6 @@ from MSMetaEnhancer.libs.converters.web.CTS import CTS
 from MSMetaEnhancer.libs.converters.web.CIR import CIR
 from MSMetaEnhancer.libs.converters.web.NLM import NLM
 from MSMetaEnhancer.libs.converters.web.PubChem import PubChem
-from MSMetaEnhancer.libs.converters.web.BridgeDB import BridgeDB
+from MSMetaEnhancer.libs.converters.web.BridgeDB import BridgeDb
 
-__all__ = ['IDSM', 'CTS', 'CIR', 'NLM', 'PubChem', 'BridgeDB']
+__all__ = ['IDSM', 'CTS', 'CIR', 'NLM', 'PubChem', 'BridgeDb']

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Conda](https://img.shields.io/conda/v/bioconda/msmetaenhancer)](https://anaconda.org/bioconda/msmetaenhancer)
 
 **MSMetaEnhancer** is a tool used for `.msp` files annotation.
-It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), [PubChem](https://pubchem.ncbi.nlm.nih.gov/), [IDSM](https://idsm.elixir-czech.cz/), and [BridgeDB](https://bridgedb.github.io/).
+It adds metadata like SMILES, InChI, and CAS number fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation), [CTS](https://cts.fiehnlab.ucdavis.edu/), [NLM](https://chem.nlm.nih.gov), [PubChem](https://pubchem.ncbi.nlm.nih.gov/), [IDSM](https://idsm.elixir-czech.cz/), and [BridgeDb](https://bridgedb.github.io/).
 The app uses asynchronous implementation of annotation process allowing for optimal fetching speed.
 
 ### Usage
@@ -24,7 +24,7 @@ app.load_spectra('tests/test_data/sample.msp', file_format='msp')
 app.curate_spectra()
 
 # specify requested services (these are supported)
-services = ['CTS', 'CIR', 'NLM', 'IDSM', 'PubChem', 'BridgeDB', 'RDKit']
+services = ['CTS', 'CIR', 'NLM', 'IDSM', 'PubChem', 'BridgeDb', 'RDKit']
 
 # specify requested jobs
 jobs = [('name', 'inchi', 'IDSM'), ('inchi', 'formula', 'IDSM'), ('inchi', 'inchikey', 'IDSM'),

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -33,7 +33,7 @@ Each record contains spectral information, i.e., peak mass to charge ratio (m/z)
 The package uses matchms [@Huber2020] for data IO and supports the open, text-based `.msp` format.
 It annotates given mass spectra records in the library file by adding missing metadata such as SMILES, InChI, and CAS numbers to the individual entries.
 The package retrieves the respective information by querying several external databases using existing metadata (e.g., SMILES or CAS number), converting different representations or database identifiers.
-Multiple databases and services are included, currently supporting the chemical identifier resolver (CIR), chemical translation service (CTS) [@Wohlgemuth2010], ChemIDplus [@tomasulo2002chemidplus], the Integrated Database for Small Molecules (IDSM) [@galgonek2021idsm], PubChem [@kim2021pubchem], and BridgeDB [@VanIersel2010].
+Multiple databases and services are included, currently supporting the chemical identifier resolver (CIR), chemical translation service (CTS) [@Wohlgemuth2010], ChemIDplus [@tomasulo2002chemidplus], the Integrated Database for Small Molecules (IDSM) [@galgonek2021idsm], PubChem [@kim2021pubchem], and BridgeDb [@VanIersel2010].
 Additionally, instead of querying external databases, computing the identifiers is also supported (e.g. molecular weight from SMILES).
 
 # Statement of need
@@ -51,7 +51,7 @@ For example, there are R packages that provide an interface to PubChem [@guha201
 Then, there are packages unifying several sources -- `webchem` [@szocs2020webchem] allows to automatically query chemical data from several web sources (similar to MSMetaEnhancer) and to interconvert between identifiers.
 The `MetaFetcheR` [@yones2021metafetcher] package focuses on database-specific identifiers and links metabolite data from several small-compound databases (e.g., PubChem, the Human Metabolome Database (HMDB) [@Wishart2022]), trying to resolve inconsistencies.
 Similarly, RaMP cross-references multiple database specific identifiers via their internal RaMP_ID to integrate various pathway and compound databases [@Zhang2018c].
-BridgeDB is an ELIXIR project providing mapping functionality of different identifiers present in HMDB (e.g., PubChemCID, ChEBI and InChIKey), gene information and several pathway databases in an organism centric manner, exposing a Java and REST API [@VanIersel2010; @Willighagen2022].
+BridgeDb is an ELIXIR project providing mapping functionality of different identifiers present in HMDB (e.g., PubChemCID, ChEBI and InChIKey), gene information and several pathway databases in an organism centric manner, exposing a Java and REST API [@VanIersel2010; @Willighagen2022].
 
 On the Python side, there are packages providing direct API access for PubChem [@swain2017], ChemSpider [@swain2018], or CIR [@swain2016].
 PubChem's public API limits programmatic access to less than ~5 requests per second, limiting the ability of advanced users to effectively mine the database.

--- a/tests/test_BridgeDB.py
+++ b/tests/test_BridgeDB.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from MSMetaEnhancer.libs.converters.web import BridgeDB
+from MSMetaEnhancer.libs.converters.web import BridgeDb
 from tests.utils import wrap_with_session
 
 
@@ -10,13 +10,13 @@ HMDBID = 'HMDB0000001'
 
 @pytest.mark.dependency()
 def test_service_available():
-    asyncio.run(wrap_with_session(BridgeDB, 'hmdbid_to_pubchemid', ['HMDB0000001']))
+    asyncio.run(wrap_with_session(BridgeDb, 'hmdbid_to_pubchemid', ['HMDB0000001']))
 
 
 @pytest.mark.dependency(depends=["test_service_available"])
 def test_format():
     args = f'Ch/{HMDBID}'
-    response = asyncio.run(wrap_with_session(BridgeDB, 'query_the_service', ['BridgeDB', args]))
+    response = asyncio.run(wrap_with_session(BridgeDb, 'query_the_service', ['BridgeDB', args]))
 
     assert type(response) == str
     lines = response.split('\n')
@@ -25,5 +25,5 @@ def test_format():
 
 
 def test_get_conversions():
-    jobs = BridgeDB(None).get_conversion_functions()
+    jobs = BridgeDb(None).get_conversion_functions()
     assert ('wikidataid', 'pubchemid', 'BridgeDB') in jobs

--- a/tests/test_BridgeDB.py
+++ b/tests/test_BridgeDB.py
@@ -16,7 +16,7 @@ def test_service_available():
 @pytest.mark.dependency(depends=["test_service_available"])
 def test_format():
     args = f'Ch/{HMDBID}'
-    response = asyncio.run(wrap_with_session(BridgeDb, 'query_the_service', ['BridgeDB', args]))
+    response = asyncio.run(wrap_with_session(BridgeDb, 'query_the_service', ['BridgeDb', args]))
 
     assert type(response) == str
     lines = response.split('\n')
@@ -26,4 +26,4 @@ def test_format():
 
 def test_get_conversions():
     jobs = BridgeDb(None).get_conversion_functions()
-    assert ('wikidataid', 'pubchemid', 'BridgeDB') in jobs
+    assert ('wikidataid', 'pubchemid', 'BridgeDb') in jobs


### PR DESCRIPTION
Changed all references of BridgeDB into BridgeDb.

@egonw please have a look if this if it is now correct everywhere, but should be fine.

Closes #131 