### PR TITLE
Prevent Throttler from freezing the whole app 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * DataFrame class to read and handle tabular metadata input [#141](https://github.com/RECETOX/MSMetaEnhancer/pull/141)
 ### Changed
 * Spectra class is an instantiation of Data class [#141](https://github.com/RECETOX/MSMetaEnhancer/pull/141)
+* fix throttling freezing the app [#144](https://github.com/RECETOX/MSMetaEnhancer/pull/144)
 ### Removed
 * retired NLM (ChemIDplus) service [#140](https://github.com/RECETOX/MSMetaEnhancer/pull/140)
 

--- a/MSMetaEnhancer/libs/utils/Throttler.py
+++ b/MSMetaEnhancer/libs/utils/Throttler.py
@@ -27,7 +27,7 @@ class Throttler:
         """
         Decrease rate (must be always positive).
         """
-        if self.rate > 0:
+        if self.rate > 1:
             self.rate -= 1
 
     def flush(self):


### PR DESCRIPTION
The `Throttler` is able to drop current requests rate to zero, which can lead to freezing the whole app. This actually explains freezing issue from #142.