### PR TITLE
PubChem blocking time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * general class Data for input handling [#141](https://github.com/RECETOX/MSMetaEnhancer/pull/141)
 * DataFrame class to read and handle tabular metadata input [#141](https://github.com/RECETOX/MSMetaEnhancer/pull/141)
+* implementation of blocking time in PubChem [#145](https://github.com/RECETOX/MSMetaEnhancer/pull/145)
 ### Changed
 * Spectra class is an instantiation of Data class [#141](https://github.com/RECETOX/MSMetaEnhancer/pull/141)
 ### Removed

--- a/MSMetaEnhancer/libs/utils/Generic.py
+++ b/MSMetaEnhancer/libs/utils/Generic.py
@@ -2,3 +2,10 @@ def escape_single_quotes(f):
     async def wrapper(self, arg):
         return await f(self, arg.replace("'", "\\'"))
     return wrapper
+
+
+def string_to_seconds(string):
+    """
+    Convert generic H:M:S string to seconds.
+    """
+    return sum(x * int(t) for x, t in zip([3600, 60, 1], string.split(":")))


### PR DESCRIPTION
Implement support for PubChem to actually read the response header for `Remaining blocking time` and apply waiting time based on this value. Its usefulness in practice needs to be verified, as it seems PubChem responds with this information very sporadically.

Close #142.