### PR TITLE
Update IDSM SPARQL queries to achieve better performance

### DIFF
--- a/tests/test_IDSM.py
+++ b/tests/test_IDSM.py
@@ -21,13 +21,15 @@ def test_service_available():
 def test_format():
     query = f"""
     SELECT DISTINCT ?value ?type
+    FROM pubchem:compound FROM pubchem:inchikey FROM descriptor:compound
     WHERE
     {{
-      ?attribute rdf:type ?type.
-      ?attribute sio:has-value ?value.
-      ?substance sio:has-attribute ?attribute.
-      ?substance sio:has-attribute ?inchi.
-      ?inchi sio:has-value "{INCHI}"@en.
+      ?compound sio:SIO_000008 [
+        rdf:type ?type;
+        sio:SIO_000300 ?value ].
+      ?compound sio:SIO_000008 [
+        rdf:type sio:CHEMINF_000396;
+        sio:SIO_000300 '{INCHI}'@en ].
     }}
     """
 


### PR DESCRIPTION
I propose to make a few changes that will significantly increase the performance of the SPARQL queries used. I have also modified the queries so that they do not use deprecated predicates now. Unfortunately, I am not familiar with your code in detail, nor with Python in general; therefore, please review whether these changes are correct.